### PR TITLE
Fix bugs in /ajax/comments.php and /inc/dropdown.class.php

### DIFF
--- a/ajax/comments.php
+++ b/ajax/comments.php
@@ -68,7 +68,9 @@ if (isset($_POST["table"])
       default :
          if ($_POST["value"] > 0) {
             $tmpname = Dropdown::getDropdownName($_POST["table"], $_POST["value"], 1);
-            echo $tmpname["comment"];
+            if(is_array($tmpname) && isset($tmpname["comment"])) {
+                echo $tmpname["comment"];
+            }
             if (isset($_POST['withlink'])) {
                echo "<script type='text/javascript' >\n";
                echo Html::jsGetElementbyID($_POST['withlink']).".

--- a/inc/dropdown.class.php
+++ b/inc/dropdown.class.php
@@ -285,7 +285,13 @@ class Dropdown {
    static function getDropdownName($table, $id, $withcomment = 0, $translate = true, $tooltip = true) {
       global $DB, $CFG_GLPI;
 
+      $dft_retval = "&nbsp;";
+
       $item = getItemForItemtype(getItemTypeForTable($table));
+
+      if( ! is_object($item)) {
+         return $dft_retval;
+      }
 
       if ($item instanceof CommonTreeDropdown) {
          return getTreeValueCompleteName($table, $id, $withcomment, $translate, $tooltip);
@@ -439,7 +445,7 @@ class Dropdown {
       }
 
       if (empty($name)) {
-         $name = "&nbsp;";
+         $name = $dft_retval;
       }
 
       if ($withcomment) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #4635

Handle case when the dropdwon class is not found and $tmpname is not an array. This makes GLPI more robust even do the situation arises because of a plugin.

Use case: Creating custom dropdowns with plugin GenericObject. Autoloaders from plugins are not available when running some GLPI ajax scripts, such as /ajax/comments.php.