### PR TITLE
Bug Fix of unnecessarily repeated queries.

### DIFF
--- a/inc/dbmysql.class.php
+++ b/inc/dbmysql.class.php
@@ -34,6 +34,7 @@ if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
 }
 
+
 /**
  *  Database class for Mysql
 **/
@@ -66,6 +67,9 @@ class DBmysql {
    public $execution_time          = false;
 
    private $cache_disabled = false;
+
+   // Ticket GitHub #5273, to avoid requesting DB each time.
+   private static $table_exists_arr = [];
 
    /**
     * Constructor / Connect to the MySQL Database
@@ -774,17 +778,23 @@ class DBmysql {
     * @return boolean
     **/
    public function tableExists($tablename) {
+      
+      if( isset(self::$table_exists_arr[$tablename]) ){
+         return self::$table_exists_arr[$tablename];
+      }
       // Get a list of tables contained within the database.
       $result = $this->listTables("%$tablename%");
 
       if (count($result)) {
          while ($data = $result->next()) {
             if ($data['TABLE_NAME'] === $tablename) {
+               self::$table_exists_arr[$tablename] = true;
                return true;
             }
          }
       }
 
+      self::$table_exists_arr[$tablename] = false;
       return false;
    }
 

--- a/inc/plugin.class.php
+++ b/inc/plugin.class.php
@@ -51,6 +51,9 @@ class Plugin extends CommonDBTM {
 
    static $rightname = 'config';
 
+   // to avoid requestig DB uselessly for thousands of time.
+   private static $is_activated_arr = [];
+   private static $is_installed_arr = [];
 
 
    /**
@@ -906,8 +909,15 @@ class Plugin extends CommonDBTM {
    **/
    function isActivated($plugin) {
 
+      if ( isset(self::$is_activated_arr[$this->getTable() . $plugin ]) ) {
+          return self::$is_activated_arr[$this->getTable() . $plugin ];
+      }
       if ($this->getFromDBbyDir($plugin)) {
-         return ($this->fields['state'] == self::ACTIVATED);
+          self::$is_activated_arr[$this->getTable() . $plugin ] = ($this->fields['state'] == self::ACTIVATED);
+          return self::$is_activated_arr[$this->getTable() . $plugin ];
+      } else {
+          self::$is_activated_arr[$this->getTable() . $plugin ] = false;
+          return false;
       }
    }
 
@@ -919,10 +929,20 @@ class Plugin extends CommonDBTM {
    **/
    function isInstalled($plugin) {
 
+      if ( isset(self::$is_installed_arr[$this->getTable() . $plugin ] )) {
+          return self::$is_installed_arr[$this->getTable() . $plugin ];
+      }
+
       if ($this->getFromDBbyDir($plugin)) {
-         return (($this->fields['state']    == self::ACTIVATED)
+         self::$is_installed_arr[$this->getTable() . $plugin ] = (
+                    ($this->fields['state'] == self::ACTIVATED)
                  || ($this->fields['state'] == self::TOBECONFIGURED)
                  || ($this->fields['state'] == self::NOTACTIVATED));
+                 
+         return self::$is_installed_arr[$this->getTable() . $plugin ];
+      } else {
+          self::$is_installed_arr[$this->getTable() . $plugin ] = false;
+          return false;
       }
    }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5273

It partially fixes the bug of having the same queries sent too many times to database in the same HTTP request, which slow down considerably the application.
The correction consists of saving the DB return values of some queries into a static (class) variable (RAM).