### PR TITLE
Bug fix to automatic tests failure of ticket #5273

### DIFF
--- a/inc/dbmysql.class.php
+++ b/inc/dbmysql.class.php
@@ -778,7 +778,13 @@ class DBmysql {
     * @return boolean
     **/
    public function tableExists($tablename) {
-      
+
+      if( $_SESSION['glpi_plugins'] == [] ){
+          self::$table_exists_arr = [];
+          Plugin::$is_activated_arr = [];
+          Plugin::$is_installed_arr = [];
+      }
+
       if( isset(self::$table_exists_arr[$tablename]) ){
          return self::$table_exists_arr[$tablename];
       }


### PR DESCRIPTION
When some install or update scripts call Update::doUpdates() which proceed to rename and/or drop tables, we must empty the cache variables where we used to save various status like isActivated, isInstalled and IfTableExists.

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5273

Original PR is : https://github.com/glpi-project/glpi/pull/5404

