### PR TITLE
Saved searches have to remember the list of displayed columns

### DIFF
--- a/front/savedsearch.form.php
+++ b/front/savedsearch.form.php
@@ -43,6 +43,12 @@ if (!isset($_GET["withtemplate"])) {
 $savedsearch = new SavedSearch();
 if (isset($_POST["add"])) {
    //Add a new saved search
+
+   // Finding the columns' list the user has chosen to view from DB to save it within this saved-search into DB.
+   // table : glpi_savedsearches, column : query
+   $pref['savedtoview'] =  DisplayPreference::getForTypeUser($_POST['itemtype'], Session::getLoginUserID());
+   $_POST['url'] .= '&' .  http_build_query($pref);
+
    $savedsearch->check(-1, CREATE, $_POST);
    if ($savedsearch->add($_POST)) {
       if ($_SESSION['glpibackcreated']) {

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -438,6 +438,13 @@ class Search {
          $data['toview'] = array_merge($data['toview'], $forcedisplay);
       }
 
+      // Overrides columns' list by the one coming from the saved search (DB).
+      // this parameter $params['savedtoview'] comes from table : glpi_savedsearches, column : query.
+      if( isset($params['savedtoview']) && is_array($params['savedtoview']) ){
+          $data['toview'] = array_merge(self::addDefaultToView($itemtype, $params), $params['savedtoview']);
+      }
+
+
       if (count($p['criteria']) > 0) {
          foreach ($p['criteria'] as $key => $val) {
             if (isset($val['field']) && !in_array($val['field'], $data['toview'])) {
@@ -1432,6 +1439,15 @@ class Search {
          return false;
       }
       // Contruct Pager parameters
+
+      // For PDF exports to match the same displayed list of columns.
+      $pref['savedtoview']   = $data['toview'];
+      $savedtoview_url       =  http_build_query( $pref );
+      $savedtoview_url       .= '&ett[0]=aa&ett[1]=bb';
+      $savedtoview_url       =  str_replace("%5B", "[", $savedtoview_url );
+      $savedtoview_url       =  str_replace("%5D", "]", $savedtoview_url );
+      $savedtoview_url       =  str_replace("&", "&amp;", $savedtoview_url );
+
       $globallinkto
          = Toolbox::append_params(['criteria'
                                           => Toolbox::stripslashes_deep($data['search']['criteria']),

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -1443,7 +1443,6 @@ class Search {
       // For PDF exports to match the same displayed list of columns.
       $pref['savedtoview']   = $data['toview'];
       $savedtoview_url       =  http_build_query( $pref );
-      $savedtoview_url       .= '&ett[0]=aa&ett[1]=bb';
       $savedtoview_url       =  str_replace("%5B", "[", $savedtoview_url );
       $savedtoview_url       =  str_replace("%5D", "]", $savedtoview_url );
       $savedtoview_url       =  str_replace("&", "&amp;", $savedtoview_url );


### PR DESCRIPTION
Also when exporting the search result into PDF format (or others)
the list of columns should match what user is seeing.

<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more informations, please check contributing guide:
https://github.com/glpi-project/glpi/blob/master/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5715
