### PR TITLE
Wanted to show [allassets] menu at all time.

### DIFF
--- a/inc/dbmysql.class.php
+++ b/inc/dbmysql.class.php
@@ -67,6 +67,9 @@ class DBmysql {
 
    private $cache_disabled = false;
 
+   // Ticket GitHub #5273, to avoid requesting DB each time.
+   static $table_exists_arr = [];
+
    /**
     * Constructor / Connect to the MySQL Database
     *
@@ -876,16 +879,38 @@ class DBmysql {
     **/
    public function tableExists($tablename) {
       // Get a list of tables contained within the database.
+
+
+      if( !isset($_SESSION['glpi_plugins']) ||
+         (isset($_SESSION['glpi_plugins']) && $_SESSION['glpi_plugins'] == [])
+         ){
+          self::$table_exists_arr = [];
+      }
+
+
+      if( isset($_POST["install"]) ||
+          !file_exists(GLPI_CONFIG_DIR . "/config_db.php") ){
+          // We are in installation mode here, so we should not
+          // rely on table_exists_arr because update scripts can rename tables or create theme !
+
+      } else {
+          if( isset(self::$table_exists_arr[$tablename]) ){
+             return self::$table_exists_arr[$tablename];
+          }
+      }
+
       $result = $this->listTables("%$tablename%");
 
       if (count($result)) {
          while ($data = $result->next()) {
             if ($data['TABLE_NAME'] === $tablename) {
+               self::$table_exists_arr[$tablename] = true;
                return true;
             }
          }
       }
 
+      self::$table_exists_arr[$tablename] = false;
       return false;
    }
 

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -1471,7 +1471,7 @@ class Html {
                             'Printer'];
 
          foreach ($allassets as $type) {
-            if (isset($menu['assets']['content'][strtolower($type)])) {
+            if ( true || isset($menu['assets']['content'][strtolower($type)])) {
                $menu['assets']['content']['allassets']['title']            = __('Global');
                $menu['assets']['content']['allassets']['shortcut']         = '';
                $menu['assets']['content']['allassets']['page']             = '/front/allassets.php';


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more informations, please check contributing guide:
https://github.com/glpi-project/glpi/blob/master/CONTRIBUTING.md

The GLPI team.
-->

Wanted to show [allassets] menu at all time.

For the time being, we should have at least one of the following menus activated for [allassets] to be shown :
['Computer', 'Monitor', 'Peripheral', 'NetworkEquipment', 'Phone', 'Printer']




| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
