### PR TITLE
Wanted menu AllAssets to appear at all time.

### DIFF
--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -1471,7 +1471,7 @@ class Html {
                             'Printer'];
 
          foreach ($allassets as $type) {
-            if (isset($menu['assets']['content'][strtolower($type)])) {
+            if ( true || isset($menu['assets']['content'][strtolower($type)])) {
                $menu['assets']['content']['allassets']['title']            = __('Global');
                $menu['assets']['content']['allassets']['shortcut']         = '';
                $menu['assets']['content']['allassets']['page']             = '/front/allassets.php';


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more informations, please check contributing guide:
https://github.com/glpi-project/glpi/blob/master/CONTRIBUTING.md

The GLPI team.
-->

current logic suggests that if none the menus ['Computer', 'Monitor', 'Peripheral', 'NetworkEquipment', 'Phone',
'Printer'] is activated then [allAssets] menu does not show up.

We want to see that menu at all time, especially when we dont use any of the objects above.

topic open at :
https://glpi.userecho.com/communities/1/topics/1027-wanted-to-see-allassets-menuat-all-times



| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
