### PR TITLE
Using a cache to know whether a table exits or not.

### DIFF
--- a/inc/dbmysql.class.php
+++ b/inc/dbmysql.class.php
@@ -67,6 +67,9 @@ class DBmysql {
 
    private $cache_disabled = false;
 
+   // Ticket GitHub #5273, to avoid requesting DB each time.
+   static $table_exists_arr = [];
+
    /**
     * Constructor / Connect to the MySQL Database
     *
@@ -876,16 +879,38 @@ class DBmysql {
     **/
    public function tableExists($tablename) {
       // Get a list of tables contained within the database.
+
+
+      if( !isset($_SESSION['glpi_plugins']) ||
+         (isset($_SESSION['glpi_plugins']) && $_SESSION['glpi_plugins'] == [])
+         ){
+          self::$table_exists_arr = [];
+      }
+
+
+      if( isset($_POST["install"]) ||
+          !file_exists(GLPI_CONFIG_DIR . "/config_db.php") ){
+          // We are in installation mode here, so we should not
+          // rely on table_exists_arr because update scripts can rename tables or create theme !
+
+      } else {
+          if( isset(self::$table_exists_arr[$tablename]) ){
+             return self::$table_exists_arr[$tablename];
+          }
+      }
+
       $result = $this->listTables("%$tablename%");
 
       if (count($result)) {
          while ($data = $result->next()) {
             if ($data['TABLE_NAME'] === $tablename) {
+               self::$table_exists_arr[$tablename] = true;
                return true;
             }
          }
       }
 
+      self::$table_exists_arr[$tablename] = false;
       return false;
    }
 


### PR DESCRIPTION
Instead of requesting DB each time.

It partially fixes the bug of having the same queries sent too many times to database in the same HTTP request, which slow down considerably the application.
The correction consists of saving the DB return values of some queries into a static (class) variable (RAM).

A part of the issue 5273 was solved otherwise by community on subsequent versions, so this PR contains only the part that was left unsolved.


<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more informations, please check contributing guide:
https://github.com/glpi-project/glpi/blob/master/CONTRIBUTING.md

The GLPI team.
-->


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5273
