### PR TITLE
Sorting dropdown elements used in search filters

### DIFF
--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -2762,6 +2762,13 @@ JAVASCRIPT;
          $value = $criteria['field'];
       }
 
+       // sorts the dropdown list elements so they will appear in order for user.
+      foreach ($values as $key => $val) {
+         if (is_array($values[$key]) && count($values[$key]) > 1) {
+             asort($values[$key], SORT_NATURAL | SORT_FLAG_CASE);
+         }
+      }
+
       $rand = Dropdown::showFromArray("criteria{$prefix}[$num][field]", $values, [
          'value' => $value,
          'width' => '170px'


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more informations, please check contributing guide:
https://github.com/glpi-project/glpi/blob/master/CONTRIBUTING.md

The GLPI team.
-->

Some users want to see elements sorted into some dropdown that are used in the search filter tool bar.

These elements don't come necessarily from DB .
asort() permits to the elements to keep their key values unchanged after sort.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5714
