### PR TITLE
 Saved searches should recall displayed column list.

### DIFF
--- a/front/savedsearch.form.php
+++ b/front/savedsearch.form.php
@@ -43,6 +43,12 @@ if (!isset($_GET["withtemplate"])) {
 $savedsearch = new SavedSearch();
 if (isset($_POST["add"])) {
    //Add a new saved search
+
+   // Finding the columns' list the user has chosen to view from DB to save it within this saved-search into DB.
+   // table : glpi_savedsearches, column : query
+   $pref['stv'] =  DisplayPreference::getForTypeUser($_POST['itemtype'], Session::getLoginUserID());
+   $_POST['url'] .= '&' .  http_build_query($pref);
+
    $savedsearch->check(-1, CREATE, $_POST);
    if ($savedsearch->add($_POST)) {
       if ($_SESSION['glpibackcreated']) {

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -574,6 +574,13 @@ class Search {
          $data['toview'] = array_merge($data['toview'], $p['forcedisplay']);
       }
 
+      // Overrides columns' list by the ones coming from the saved search (DB).
+      // this parameter $params['stv'] comes from table : glpi_savedsearches, column : query.
+      // stv is a shortcut savedtoview, this is because GET method URLs have limit for length.
+      if (isset($params['stv']) && is_array($params['stv'])) {
+          $data['toview'] = array_merge(self::addDefaultToView($itemtype, $params), $params['stv']);
+      }
+
       if (count($p['criteria']) > 0) {
          // use a recursive clojure to push searchoption when using nested criteria
          $parse_criteria = function($criteria) use (&$parse_criteria, &$data) {
@@ -1692,13 +1699,21 @@ class Search {
       if (!isset($data['data']) || !isset($data['data']['totalcount'])) {
          return false;
       }
+
+      // For PDF exports to match the same displayed list of columns.
+      $pref['stv']   = $data['toview'];
+      $savedtoview_url       =  http_build_query($pref);
+      $savedtoview_url       =  str_replace("%5B", "[", $savedtoview_url);
+      $savedtoview_url       =  str_replace("%5D", "]", $savedtoview_url);
+      $savedtoview_url       =  str_replace("&", "&amp;", $savedtoview_url);
+
       // Contruct Pager parameters
       $globallinkto
          = Toolbox::append_params(['criteria' => $data['search']['criteria'],
                                    'metacriteria' => $data['search']['metacriteria']],
                                   '&amp;');
       $parameters = "sort=".$data['search']['sort']."&amp;order=".$data['search']['order'].'&amp;'.
-                     $globallinkto;
+                     $globallinkto . '&amp;' . $savedtoview_url;
 
       if (isset($_GET['_in_modal'])) {
          $parameters .= "&amp;_in_modal=1";


### PR DESCRIPTION
<!--

Dear GLPI user.

BEFORE SUBMITTING YOUR ISSUE, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Please use the below template.

For more informations, please check contributing guide:
https://github.com/glpi-project/glpi/blob/master/CONTRIBUTING.md

The GLPI team.
-->

Saved searches should recall displayed column list

We also want to see the same list of columns printed into PDF format
for example.

Currently saved searches dont show the original list of columns that has been the first time the search has been created. the same error occurs when exporting a search result; what is exported does not match what is seen by the user !

This PR is linked to the discussed idea in the following link : [click here](https://glpi.userecho.com/communities/1/topics/1015-saved-searches-dont-recall-the-list-of-displayed-columns).




| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number
