### PR TITLE
bugfixv2 - Make GLPI dropdowns compatible with html input arrays

### DIFF
--- a/inc/dropdown.class.php
+++ b/inc/dropdown.class.php
@@ -215,9 +215,9 @@ class Dropdown {
              && $params['addicon']) {
 
                $output .= "<span class='fa fa-plus-circle pointer' title=\"".__s('Add')."\"
-                            onClick=\"".Html::jsGetElementbyID('add_dropdown'.$params['name'].$params['rand']).".dialog('open');\"
+                            onClick=\"".Html::jsGetElementbyID('add_dropdown'.$field_id.$params['rand']).".dialog('open');\"
                            ><span class='sr-only'>" . __s('Add') . "</span></span>";
-               $output .= Ajax::createIframeModalWindow('add_dropdown'.$params['name'].$params['rand'],
+               $output .= Ajax::createIframeModalWindow('add_dropdown'.$field_id.$params['rand'],
                                                         $item->getFormURL(),
                                                         ['display' => false]);
          }

--- a/inc/dropdown.class.php
+++ b/inc/dropdown.class.php
@@ -215,9 +215,9 @@ class Dropdown {
              && $params['addicon']) {
 
                $output .= "<span class='fa fa-plus-circle pointer' title=\"".__s('Add')."\"
-                            onClick=\"".Html::jsGetElementbyID('add_dropdown'.$field_id.$params['rand']).".dialog('open');\"
+                            onClick=\"".Html::jsGetElementbyID('add_dropdown'.$params['name'].$params['rand']).".dialog('open');\"
                            ><span class='sr-only'>" . __s('Add') . "</span></span>";
-               $output .= Ajax::createIframeModalWindow('add_dropdown'.$field_id.$params['rand'],
+               $output .= Ajax::createIframeModalWindow('add_dropdown'.$params['name'].$params['rand'],
                                                         $item->getFormURL(),
                                                         ['display' => false]);
          }


### PR DESCRIPTION
Bugfix for allowing Dropdown::show to handle html input arrays (ie.: inputs with names like foo[]).

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #6079
